### PR TITLE
New logging approach, uuid for window and reduce vapor logging

### DIFF
--- a/velocity/capture.swift
+++ b/velocity/capture.swift
@@ -59,7 +59,9 @@ func create_hidden_window(_ virtual_machine_view: VZVirtualMachineView, vm_view_
     offscreen_window.standardWindowButton(.miniaturizeButton)?.isHidden = true
     offscreen_window.standardWindowButton(.closeButton)?.isHidden = true
     offscreen_window.standardWindowButton(.zoomButton)?.isHidden = true
-     
+    let window_uuid = UUID().uuidString;
+    offscreen_window.title = window_uuid;
+
     // position the windows frame at -10k, so it is far offscreen
     let offscreenFrame = CGRect(x: -10000, y: -10000, width: Int(vm_view_size.width), height: Int(vm_view_size.height))
     offscreen_window.setFrame(offscreenFrame, display: false)

--- a/velocity/httpserver.swift
+++ b/velocity/httpserver.swift
@@ -29,11 +29,12 @@ struct Message: Codable {
 public func start_web_server(velocity_config: VelocityConfig) throws {
     let app: Application?
     do {
-         app = try Application(.detect())
+        app = try Application(.detect())
     } catch {
         throw VelocityWebError("Could not setup WS: \(error.localizedDescription)")
     }
-    
+    app?.logger.logLevel = Logger.Level.error;
+
     // CORS headers
     let corsConfiguration = CORSMiddleware.Configuration(
         allowedOrigin: .all,

--- a/velocity/log.swift
+++ b/velocity/log.swift
@@ -7,6 +7,70 @@
 
 import Foundation
 
-func VLog(_ message: String) {
-    NSLog("[Velocity] \(message)")
+/// The loglevels for logging
+enum Loglevel: Int {
+    case Err
+    case Warn
+    case Info
+    case Debug
+    case Trace
+}
+
+/// The current loglevel to use
+var VLoglevel: Loglevel = Loglevel.Trace;
+
+/// Log the specified message to the log
+/// - Parameter message: The message to print
+/// - Parameter level: The loglevel to use (optional) if `nil`, this will always print
+func VLog(_ message: String, level: Loglevel? = nil) {
+    if let level = level {
+        //Early return if the loglevel is too low
+        if VLoglevel.rawValue < level.rawValue {
+            return;
+        }
+
+        var c = "I";
+
+        switch level {
+        case Loglevel.Err: c = "E"
+        case Loglevel.Warn: c = "W"
+        case Loglevel.Info: c = "I"
+        case Loglevel.Debug: c = "D"
+        case Loglevel.Trace: c = "T"
+        }
+
+        NSLog("[Velocity][\(c)] \(message)");
+    } else {
+        NSLog("[Velocity] \(message)");
+    }
+}
+
+/// Log the specified message under the `Err` loglevel
+/// - Parameter message: The message to print
+func VErr(_ message: String) {
+    VLog(message, level: Loglevel.Err);
+}
+
+/// Log the specified message under the `Warn` loglevel
+/// - Parameter message: The message to print
+func VWarn(_ message: String) {
+    VLog(message, level: Loglevel.Warn);
+}
+
+/// Log the specified message under the `Info` loglevel
+/// - Parameter message: The message to print
+func VInfo(_ message: String) {
+    VLog(message, level: Loglevel.Info);
+}
+
+/// Log the specified message under the `Debug` loglevel
+/// - Parameter message: The message to print
+func VDebug(_ message: String) {
+    VLog(message, level: Loglevel.Debug);
+}
+
+/// Log the specified message under the `Trace` loglevel
+/// - Parameter message: The message to print
+func VTrace(_ message: String) {
+    VLog(message, level: Loglevel.Trace);
 }


### PR DESCRIPTION
This contribution adds a new and more robust approach to logging.
The window now receives a UUID as the title for rediscovering it for capturing later.
The logging verbosity for vapor has been reduced.