### PR TITLE
Add VM listing and information endpoints

### DIFF
--- a/docs/APISPEC/v.md
+++ b/docs/APISPEC/v.md
@@ -30,6 +30,12 @@ A user can request state changes from the server, but can only transition to tho
 
 [Virtual machine management](#v-vm)
 
+- VM management
+  
+  - [`/v/vm/list` - POST](#post-v-vm-list): List all available virtual machines
+  
+  - [`/v/vm` - POST](#post-v-vm): Get information about a virtual machine
+
 - VM creation
   
   - [`/v/vm/efi` - PUT](#put-v-vm-efi): Create a `EFI` virtual machine
@@ -47,6 +53,105 @@ A user can request state changes from the server, but can only transition to tho
 - [`/v/nic/list` - POST](#post-v-nic-list): List available host NICs
 
 # Virtual machine management <a name="v-vm"></a>
+
+# `/v/vm/list` - POST <a name="post-v-vm-list"></a>
+
+List all available virtual machines for a group
+
+> **Note**
+> 
+> The calling user needs the `velocity.vm.view` permission on the target group
+
+**Request:**
+
+```json
+{
+  "authkey": "<authkey>",
+  "gid": "<GID>",
+}
+```
+
+**Response:**
+
+- `200`:
+
+```json
+{
+  "vms": [
+    {
+      "vmid": "<VMID>",
+      "name": "<Name>",
+      "cpus": "<CPU count>",
+      "memory_mib": "<Memory in MiB>",
+      "state": "<VM state>"
+    }
+  ]
+}
+```
+
+- `401 - Unauthorized`: The calling user lacks permissions
+
+- `404 - Not Found`: The `GID` couldn't be found
+
+# `/v/vm` - POST <a name="post-v-vm"></a>
+
+Retrieve information about a virtual machine
+
+> **Note**
+> 
+> The calling user needs the `velocity.vm.view` permission on the group owning the VM
+
+**Request:**
+
+```json
+{
+    "authkey": "<authkey>",
+    "vmid": "<VMID>"
+}
+```
+
+**Response:**
+
+- `200`:
+
+```json
+{
+  "vmid": "<VMID>",
+  "name": "<VM name>",
+  "type": "<EFI/...>",
+  "state": "<VM state>",
+
+  "cpus": "<Amount of CPUs assigned>",
+  "memory_mib": "<Memory size in MiB>",
+
+  "displays": [
+    {
+      "name": "<Friendly name>",
+      "width": "<Screen width>",
+      "height": "<Screen height>",
+      "ppi": "<Pixels per inch>"
+    }
+  ],
+  "media": [
+    {
+      "mid": "<MID>",
+      "mode": "<USB / BLOCK / VIRTIO>",
+      "readonly": true
+    }
+  ],
+  "nics": [
+    {
+      "type": "<NAT / BRIDGE>",
+      "host": "<Host NICID (BRIDGE only)>"
+    }
+  ],
+
+  "rosetta": true,
+  "autostart": true
+}
+```
+
+- `404 - Not Found`: The `VMID` couldn't be found or the user lacks permissions to view the vm
 
 # `/v/vm/efi` - PUT <a name="put-v-vm-efi"></a>
 

--- a/velocity/api/vAPIError.swift
+++ b/velocity/api/vAPIError.swift
@@ -227,6 +227,16 @@ extension VAPI {
         /// `/v/vm/state - PUT`: The requested state transition can not be completed
         case V_VM_STATE_PUT_NOT_ALLOWED = 13220
 
+        // MARK: /v/vm: 16xxx
+
+        /// `/v/vm - POST`: The requested VMID has not been found
+        case V_VM_POST_VM_NOT_FOUND = 16210
+
+        // MARK: /v/vm/list: 17xxx
+
+        /// `/v/vm/list - POST`: The group has not been found
+        case V_VM_LIST_POST_GROUP_NOT_FOUND = 17210
+
     }
 }
 
@@ -356,6 +366,12 @@ extension VAPI.ErrorCode {
         case .V_VM_STATE_PUT_PERMISSION: return .forbidden
         case .V_VM_STATE_PUT_VM_NOT_FOUND: return .notFound
         case .V_VM_STATE_PUT_NOT_ALLOWED: return .notAcceptable
+
+        // /v/vm - POST
+        case .V_VM_POST_VM_NOT_FOUND: return .notFound
+
+        // /v/vm/list - POST
+        case .V_VM_LIST_POST_GROUP_NOT_FOUND: return .notFound
         }
     }
 
@@ -482,6 +498,12 @@ extension VAPI.ErrorCode {
         case .V_VM_STATE_PUT_PERMISSION: return "Permission 'velocity.vm.state' is needed"
         case .V_VM_STATE_PUT_VM_NOT_FOUND: return "Virtual machine has not been found"
         case .V_VM_STATE_PUT_NOT_ALLOWED: return "State transition not allowed"
+
+        // /v/vm - POST
+        case .V_VM_POST_VM_NOT_FOUND: return "Virtual machine has not been found or is not accessible"
+
+        // /v/vm/list - POST
+        case .V_VM_LIST_POST_GROUP_NOT_FOUND: return "Group has not been found"
         }
     }
 }

--- a/velocity/db/tables/vDBTUsers.swift
+++ b/velocity/db/tables/vDBTUsers.swift
@@ -8,6 +8,9 @@
 import Foundation
 import SQLite
 
+/// The user id is a Int64
+typealias UID = Int64
+
 extension VDB {
 
     /// A user in the database

--- a/velocity/db/tables/vDBTVMDisks.swift
+++ b/velocity/db/tables/vDBTVMDisks.swift
@@ -142,7 +142,7 @@ extension VDB {
         }
 
         /// All possible modes a disk can be attached
-        enum DiskMode : String, Decodable {
+        enum DiskMode : String, Decodable, Encodable {
             case USB = "USB"
             case VIRTIO = "VIRTIO"
 

--- a/velocity/db/tables/vDBTVMNICs.swift
+++ b/velocity/db/tables/vDBTVMNICs.swift
@@ -75,7 +75,7 @@ extension VDB {
         }
 
         /// The possible modes for a NIC
-        enum NICType : String, Decodable {
+        enum NICType : String, Decodable, Encodable {
             case NAT = "NAT"
             case BRIDGE = "BRIDGE"
         }

--- a/velocity/manager/vmmanager.swift
+++ b/velocity/manager/vmmanager.swift
@@ -47,7 +47,7 @@ class VMManager : Loggable {
         self.db = db
 
         // Iterate over all virtual machines available in the database
-        for vm in try self.db.t_vms.get_all_vms(db: self.db) {
+        for vm in try self.db.vms_get(group: nil) {
 
             VDebug("Loading virtual machine '\(vm.name)' [\(vm.vmid)]")
 

--- a/velocity/virt/vz/diskconfiguration.swift
+++ b/velocity/virt/vz/diskconfiguration.swift
@@ -28,7 +28,7 @@ import Virtualization
 extension VZ {
 
     /// A disk configuration that can be used to create a `VZStorageDeviceConfiguration`
-    struct DiskConfiguration {
+    struct DiskConfiguration : Encodable {
 
         /// The piece of media this disk wraps
         let media: VDB.Media
@@ -50,6 +50,21 @@ extension VZ {
             case .VIRTIO:
                 return VZVirtioBlockDeviceConfiguration(attachment: attachment)
             }
+        }
+
+        /// Provide coding keys for encoding this type
+        enum CodingKeys: String, CodingKey {
+            case mid
+            case mode
+            case readonly
+        }
+
+        /// Implement `Encodable`
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.media.mid, forKey: .mid)
+            try container.encode(self.mode, forKey: .mode)
+            try container.encode(self.readonly, forKey: .readonly)
         }
     }
 }

--- a/velocity/virt/vz/displayconfiguration.swift
+++ b/velocity/virt/vz/displayconfiguration.swift
@@ -29,7 +29,7 @@ import Virtualization
 extension VZ {
 
     /// A structure that describes a display for a virtual machine
-    struct DisplayConfiguration {
+    struct DisplayConfiguration : Encodable {
 
         /// A friendly name for the display
         let name: String
@@ -44,7 +44,6 @@ extension VZ {
         func get_scanout() -> VZVirtioGraphicsScanoutConfiguration {
             return VZVirtioGraphicsScanoutConfiguration(widthInPixels: Int(self.width), heightInPixels: Int(self.height))
         }
-
     }
 
 }

--- a/velocity/virt/vz/nicconfiguration.swift
+++ b/velocity/virt/vz/nicconfiguration.swift
@@ -29,7 +29,7 @@ import Virtualization
 extension VZ {
 
     /// A NIC configuration that can be converted to a `VZNetworkDeviceConfiguration`
-    enum NICConfiguration {
+    enum NICConfiguration : Encodable {
 
         /// A NAT NIC
         case NAT
@@ -48,6 +48,24 @@ extension VZ {
             }
 
             return configuration
+        }
+
+        /// Provide coding keys for encoding this type
+        enum CodingKeys: String, CodingKey {
+            case type
+            case host
+        }
+
+        /// Implement `Encodable`
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .NAT:
+                try container.encode("NAT", forKey: .type)
+            case .BRIDGE(let host):
+                try container.encode("BRIDGE", forKey: .type)
+                try container.encode(host.nicid, forKey: .host)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds the following new endpoints and their documentation:
- `/v/vm/ - POST`: Get information about a virtual machine
- `/v/vm/list - POST`: List all virtual machines for a group