### PR TITLE
Add the previously removed signal handler

### DIFF
--- a/velocity/main.swift
+++ b/velocity/main.swift
@@ -25,6 +25,14 @@ public func main() {
         VInfo("Running in XCode, no escape codes")
     }
 
+    let signal_source = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main);
+    signal_source.setEventHandler {
+        /// TODO: Properly shutdown webserver & rfb server, send shutdown req to VMs..
+        exit(0);
+    }
+    signal(SIGINT, SIG_IGN);
+    signal_source.resume();
+
     VInfo("Starting up..")
     VelocityConfig.setup()
 


### PR DESCRIPTION
This simple signal handler allows Velocity to be CTRL+c'd, instead of having to kill -9 it. It doesn't properly handle the shutdown, but still an improvement over having to open another shell to kill it.