### PR TITLE
Implement 'Bearer' authentication method

### DIFF
--- a/docs/APISPEC/README.md
+++ b/docs/APISPEC/README.md
@@ -16,6 +16,12 @@ The API is divided into several namespaces:
 - [`/m`](m.md): Pool and media management
 - [`/v`](v.md): Virtual machine management
 
+### Authentication
+
+Velocity handles authentication using the `Bearer` authentication method with the token being aliased as the `Authkey`.
+
+Refer to the [Vapor manual](https://docs.vapor.codes/security/authentication/#bearer) for more information.
+
 ### Errors
 
 If the API enconters some kind of error, it will respond with a http-response code in a non-200 range and an error as follows:

--- a/docs/APISPEC/m.md
+++ b/docs/APISPEC/m.md
@@ -55,7 +55,6 @@ If the group is already assigned to the pool, this call will update the permissi
 
 ```json
 {
-    "authkey": "<authkey>",
     "gid": "<GID>",
     "mpid": "<MPID>",
     "quota": "<Quota in Bytes>",
@@ -84,7 +83,6 @@ Revoke a group's permissions from a mediapool
 
 ```json
 {
-    "authkey": "<authkey>",
     "gid": "<GID>",
     "mpid": "<MPID>"
 }
@@ -110,7 +108,6 @@ List back available pools for a group
 
 ```json
 {
-    "authkey": "<authkey>",
     "gid": "<GID>"
 }
 ```
@@ -150,7 +147,6 @@ Allocate new media on a pool (`pid`) owned by a group (`gid`)
 
 ```json
 {
-    "authkey": "<authkey>",
     "mpid": "<MPID>",
     "gid": "<GID>",
     "name": "<Media name>",
@@ -184,11 +180,9 @@ In contrast to the whole rest of the Velocity API, uploads are handled uniquely:
 
 **Request:**
 
-- `HTTP` Header:
+- `HTTP` Additional HTTP Headers:
   
   - `Content-Length`: The amount of bytes to be submitted. The server will not accept any more bytes than specified here
-  
-  - `x-velocity-authkey`: The `authkey`
   
   - `x-velocity-mpid`: The mediapool id (`MPID`)
   
@@ -235,7 +229,6 @@ Remove media (delete it)
 
 ```json
 {
-    "authkey": "<authkey>",
     "mid": "<MID>"
 }
 ```
@@ -260,7 +253,6 @@ List back available media to a group
 
 ```json
 {
-    "authkey": "<authkey>",
     "gid": "<GID>"
 }
 ```

--- a/docs/APISPEC/u.md
+++ b/docs/APISPEC/u.md
@@ -137,7 +137,7 @@ If an authkey lease is about to expire, this call can be used to create a new au
 
 ## `/u/user` - POST <a name="post-u-user"></a>
 
-Retrieve information about the current user. The `authkey` is used to infer the user, unless the `uid` field is specified.
+Retrieve information about the current user. The request's `authkey` is used to infer the user, unless the `uid` field is specified.
 
 > **Note**
 > 
@@ -147,7 +147,6 @@ Retrieve information about the current user. The `authkey` is used to infer the 
 
 ```json
 {
-  "authkey": "<authkey>",
   "uid": "<UID (optional)>"
 }
 ```
@@ -192,7 +191,6 @@ Create a new user
 
 ```json
 {
-  "authkey": "<authkey>",
   "name": "<username>",
   "password": "<password>"
 }
@@ -225,7 +223,6 @@ This call removes the user with the supplied `UID`. This also removes the user's
 
 ```json
 {
-  "authkey": "<authkey>",
   "uid": "<UID>"
 }
 ```
@@ -249,9 +246,7 @@ List all users on this velocity instance
 **Request:**
 
 ```json
-{
-  "authkey": "<authkey>"
-}
+<NO BODY>
 ```
 
 **Response:**
@@ -289,7 +284,6 @@ Put new permissions for a user on a specific group
 
 ```json
 {
-  "authkey": "<authkey>",
   "uid": "<UID>",
   "gid": "<GID>",
   "permission": "<permission identifier>"
@@ -318,7 +312,6 @@ Remove user permissions
 
 ```json
 {
-  "authkey": "<authkey>",
   "uid": "<UID>",
   "gid": "<GID>",
   "permission": "<permission>"
@@ -349,7 +342,6 @@ Retrieve information about a group
 
 ```json
 {
-  "authkey": "<authkey>",
   "gid": "<GID>"
 }
 ```
@@ -395,7 +387,6 @@ Create a new group. There cannot be duplicate group names in a parent group.
 
 ```json
 {
-  "authkey": "<authkey>",
   "name": "<groupname>",
   "parent_gid": "<GID>"
 }
@@ -433,7 +424,6 @@ This call removes all the VMs and images owned by this group.
 
 ```json
 {
-  "authkey": "<authkey>",
   "gid": "<GID>"
 }
 ```
@@ -459,9 +449,7 @@ List back all existing groups on this velocity instance
 **Request:**
 
 ```json
-{
-  "authkey": "<authkey>"
-}
+<NO BODY>
 ```
 
 **Response:**

--- a/docs/APISPEC/v.md
+++ b/docs/APISPEC/v.md
@@ -165,7 +165,6 @@ Create a new virtual machineCreate a new `EFI` virtual machine using the supplie
 
 ```json
 {
-  "authkey": "<authkey>",
   "name": "<VM name>",
   "gid": "<GID>",
 
@@ -274,7 +273,6 @@ Request the current vm [state](#vm-states)
 
 ```json
 {
-  "authkey": "<authkey>",
   "vmid": "<VMID>"
 }
 ```
@@ -312,7 +310,6 @@ Request a [state change](#vm-states) for the virtual machine. Valid states:
 
 ```json
 {
-  "authkey": "<authkey>",
   "vmid": "<VMID>",
   "state": "<VM state>",
   "force": true
@@ -351,9 +348,7 @@ List all available host `NICs` available for `BRIDGE` use
 **Request:**
 
 ```json
-{
-  "authkey": "<authkey>"
-}
+<NO BODY>
 ```
 
 **Response:**

--- a/velocity/api/namespaces/vAPI_m/vAPI_m_media.swift
+++ b/velocity/api/namespaces/vAPI_m/vAPI_m_media.swift
@@ -263,7 +263,6 @@ extension VAPI.Structs.M {
             /// `/m/media/list` - POST
             struct POST {
                 struct Req : Decodable {
-                    let authkey: String
                     let gid: GID
                 }
                 struct Res : Encodable {
@@ -284,7 +283,6 @@ extension VAPI.Structs.M {
             /// `/m/media/create` - PUT
             struct PUT {
                 struct Req : Decodable {
-                    let authkey: String
                     let mpid: MPID
                     let gid: Int64
                     let name: String

--- a/velocity/api/namespaces/vAPI_m/vAPI_m_media.swift
+++ b/velocity/api/namespaces/vAPI_m/vAPI_m_media.swift
@@ -29,14 +29,13 @@ extension VAPI {
     /// Registers all endpoints withing the namespace `/m/media`
     func register_endpoints_m_media(route: RoutesBuilder) throws {
 
-        route.post("list") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .post("list") { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.M.MEDIA.LIST.POST.Req = try req.content.decode(Structs.M.MEDIA.LIST.POST.Req.self)
-
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard try c_user.has_permission(permission: "velocity.media.list", group: nil) else {
                 self.VDebug("\(c_user.info()) tried to list media for group \(request.gid): FORBIDDEN")
@@ -64,32 +63,31 @@ extension VAPI {
             return try self.response(Structs.M.MEDIA.LIST.POST.Res(media: media_info))
         }
 
-        route.put("create") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .put("create") { req in
+
             let request: Structs.M.MEDIA.CREATE.PUT.Req = try req.content.decode(Structs.M.MEDIA.CREATE.PUT.Req.self)
+            let c_user = try req.auth.require(VDB.User.self)
 
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let user = key.user
-
-            guard try user.has_permission(permission: "velocity.media.create", group: nil) else {
-                self.VDebug("\(user.info()) tried to create new media '\(request.name)': FORBIDDEN")
+            guard try c_user.has_permission(permission: "velocity.media.create", group: nil) else {
+                self.VDebug("\(c_user.info()) tried to create new media '\(request.name)': FORBIDDEN")
                 return try self.error(code: .M_MEDIA_CREATE_PUT_PERMISSION)
             }
 
             guard let pool = self.db.pool_get(mpid: request.mpid) else {
-                self.VDebug("\(user.info()) tried to create new media '\(request.name)': MEDIAPOOL NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to create new media '\(request.name)': MEDIAPOOL NOT FOUND")
                 return try self.error(code: .M_MEDIA_CREATE_PUT_MEDIAPOOL_NOT_FOUND)
             }
 
             guard let group = try self.db.group_select(gid: request.gid) else {
-                self.VDebug("\(user.info()) tried to create new media '\(request.name)': GROUP NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to create new media '\(request.name)': GROUP NOT FOUND")
                 return try self.error(code: .M_MEDIA_CREATE_PUT_GROUP_NOT_FOUND)
             }
 
             guard try group.can_manage(pool: pool) else {
-                self.VDebug("\(user.info()) tried to create media in pool \(pool.name): Group lacks 'manage' permission")
+                self.VDebug("\(c_user.info()) tried to create media in pool \(pool.name): Group lacks 'manage' permission")
                 return try self.error(code: .M_MEDIA_CREATE_PUT_GROUP_PERMISSION)
             }
 
@@ -99,19 +97,24 @@ extension VAPI {
             case .failure(let error):
                 switch error {
                 case .Duplicate:
-                    self.VDebug("\(user.info()) tried to create new media '\(request.name)': DUPLICATE")
+                    self.VDebug("\(c_user.info()) tried to create new media '\(request.name)': DUPLICATE")
                     return try self.error(code: .M_MEDIA_CREATE_PUT_CONFLICT)
                 case .Quota:
-                    self.VDebug("\(user.info()) tried to create new media '\(request.name)': QUOTA SURPASSED")
+                    self.VDebug("\(c_user.info()) tried to create new media '\(request.name)': QUOTA SURPASSED")
                     return try self.error(code: .M_MEDIA_CREATE_PUT_QUOTA)
                 }
             case .success(let media):
-                self.VDebug("\(user.info()) created new media '\(media.name)' of \(media.size) bytes: \(media.mid)")
+                self.VDebug("\(c_user.info()) created new media '\(media.name)' of \(media.size) bytes: \(media.mid)")
                 return try self.response(Structs.M.MEDIA.CREATE.PUT.Res(mid: media.mid, size: media.size))
             }
         }
 
-        route.on(.PUT, "upload", body: .stream) { req -> EventLoopFuture<Response> in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .on(.PUT, "upload", body: .stream) { req -> EventLoopFuture<Response> in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let promise = req.eventLoop.makePromise(of: Void.self)
 
             // MARK: Gather all fields
@@ -121,10 +124,6 @@ extension VAPI {
             }
             guard let content_length: Int64 = Int64(content_length) else {
                 return try self.promise_error(promise, code: .M_MEDIA_UPLOAD_PUT_CONTENT_LENGTH, "Need a Int")
-            }
-
-            guard let authkey = req.headers["x-velocity-authkey"].first else {
-                return try self.promise_error(promise, code: .M_MEDIA_UPLOAD_PUT_X_VELOCITY_AUTHKEY, "Field missing")
             }
 
             guard let mpid = req.headers["x-velocity-mpid"].first else {
@@ -159,11 +158,6 @@ extension VAPI {
 
             // MARK: Check validity
 
-            guard let key = self.get_authkey(authkey: authkey) else {
-                return try self.promise_error(promise, code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard try c_user.has_permission(permission: "velocity.media.create", group: nil) else {
                 self.VDebug("\(c_user.info()) tried to upload media '\(name)': FORBIDDEN")

--- a/velocity/api/namespaces/vAPI_m/vAPI_m_pool.swift
+++ b/velocity/api/namespaces/vAPI_m/vAPI_m_pool.swift
@@ -29,87 +29,85 @@ extension VAPI {
     /// Registers all endpoints withing the namespace `/m/pool`
     func register_endpoints_m_pool(route: RoutesBuilder) throws {
 
-        route.put("assign") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .put("assign") { req in
+
             let request: Structs.M.POOL.ASSIGN.PUT.Req = try req.content.decode(Structs.M.POOL.ASSIGN.PUT.Req.self)
+            let c_user = try req.auth.require(VDB.User.self)
 
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let user = key.user
-
-            guard try user.has_permission(permission: "velocity.pool.assign", group: nil) else {
-                self.VDebug("\(user.info()) tried to assign group (\(request.gid)) to pool (\(request.mpid)): FORBIDDEN")
+            guard try c_user.has_permission(permission: "velocity.pool.assign", group: nil) else {
+                self.VDebug("\(c_user.info()) tried to assign group (\(request.gid)) to pool (\(request.mpid)): FORBIDDEN")
                 return try self.error(code: .M_POOL_ASSIGN_PUT_PERMISSION)
             }
 
             guard let group = try self.db.group_select(gid: request.gid) else {
-                self.VDebug("\(user.info()) tried to assign group (\(request.gid)) to pool (\(request.mpid)): GROUP NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to assign group (\(request.gid)) to pool (\(request.mpid)): GROUP NOT FOUND")
                 return try self.error(code: .M_POOL_ASSIGN_PUT_GROUP_NOT_FOUND)
             }
 
             guard let pool = self.db.pool_get(mpid: request.mpid) else {
-                self.VDebug("\(user.info()) tried to assign \(group.info()) to pool (\(request.mpid)): MEDIAPOOL NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to assign \(group.info()) to pool (\(request.mpid)): MEDIAPOOL NOT FOUND")
                 return try self.error(code: .M_POOL_ASSIGN_PUT_MEDIAPOOL_NOT_FOUND)
             }
 
             try pool.assign(db: self.db, group: group, quota: request.quota, write: request.write, manage: request.write)
-            self.VDebug("\(user.info()) assigned \(group.info()) to pool (\(pool.name)): write: \(request.write), manage: \(request.manage)")
+            self.VDebug("\(c_user.info()) assigned \(group.info()) to pool (\(pool.name)): write: \(request.write), manage: \(request.manage)")
 
             return try self.response(nil)
         }
 
-        route.delete("assign") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .delete("assign") { req in
+
             let request: Structs.M.POOL.ASSIGN.DELETE.Req = try req.content.decode(Structs.M.POOL.ASSIGN.DELETE.Req.self)
+            let c_user = try req.auth.require(VDB.User.self)
 
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let user = key.user
-
-            guard try user.has_permission(permission: "velocity.pool.revoke", group: nil) else {
-                self.VDebug("\(user.info()) tried to revoke group (\(request.gid)) from pool (\(request.mpid)): FORBIDDEN")
+            guard try c_user.has_permission(permission: "velocity.pool.revoke", group: nil) else {
+                self.VDebug("\(c_user.info()) tried to revoke group (\(request.gid)) from pool (\(request.mpid)): FORBIDDEN")
                 return try self.error(code: .M_POOL_ASSIGN_DELETE_PERMISSION)
             }
 
             guard let group = try self.db.group_select(gid: request.gid) else {
-                self.VDebug("\(user.info()) tried to revoke group (\(request.gid)) from pool (\(request.mpid)): GROUP NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to revoke group (\(request.gid)) from pool (\(request.mpid)): GROUP NOT FOUND")
                 return try self.error(code: .M_POOL_ASSIGN_PUT_GROUP_NOT_FOUND)
             }
 
             guard let pool = self.db.pool_get(mpid: request.mpid) else {
-                self.VDebug("\(user.info()) tried to revoke \(group.info()) from pool (\(request.mpid)): MEDIAPOOL NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to revoke \(group.info()) from pool (\(request.mpid)): MEDIAPOOL NOT FOUND")
                 return try self.error(code: .M_POOL_ASSIGN_PUT_MEDIAPOOL_NOT_FOUND)
             }
 
             try pool.revoke(db: self.db, group: group)
-            self.VDebug("\(user.info()) revoked \(group.info()) from pool (\(pool.name))")
+            self.VDebug("\(c_user.info()) revoked \(group.info()) from pool (\(pool.name))")
 
             return try self.response(nil)
         }
 
-        route.post("list") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .post("list") { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.M.POOL.LIST.POST.Req = try req.content.decode(Structs.M.POOL.LIST.POST.Req.self)
 
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
 
-            let user = key.user
-
-            guard try user.has_permission(permission: "velocity.pool.list", group: nil) else {
-                self.VDebug("\(user.info()) tried to list available pools: FORBIDDEN")
+            guard try c_user.has_permission(permission: "velocity.pool.list", group: nil) else {
+                self.VDebug("\(c_user.info()) tried to list available pools: FORBIDDEN")
                 return try self.error(code: .M_POOL_LIST_POST_PERMISSION)
             }
 
             guard let group = try self.db.group_select(gid: request.gid) else {
-                self.VDebug("\(user.info()) tried to list pools of group (\(request.gid)): GROUP NOT FOUND")
+                self.VDebug("\(c_user.info()) tried to list pools of group (\(request.gid)): GROUP NOT FOUND")
                 return try self.error(code: .M_POOL_LIST_POST_GROUP_NOT_FOUND)
             }
 
             let pools = try group.get_mediapools_info()
-            self.VDebug("\(user.info()) requested mediapool list: \(pools.count) pools")
+            self.VDebug("\(c_user.info()) requested mediapool list: \(pools.count) pools")
 
             return try self.response(Structs.M.POOL.LIST.POST.Res(pools: pools))
         }

--- a/velocity/api/namespaces/vAPI_m/vAPI_m_pool.swift
+++ b/velocity/api/namespaces/vAPI_m/vAPI_m_pool.swift
@@ -122,7 +122,6 @@ extension VAPI.Structs.M {
             /// `/m/pool/assign` - PUT
             struct PUT {
                 struct Req : Decodable {
-                    let authkey: String
                     let gid: GID
                     let mpid: MPID
                     let quota: Int64
@@ -133,7 +132,6 @@ extension VAPI.Structs.M {
             /// `/m/pool/assign` - DELETE
             struct DELETE {
                 struct Req : Decodable {
-                    let authkey: String
                     let gid: GID
                     let mpid: MPID
                 }
@@ -145,7 +143,6 @@ extension VAPI.Structs.M {
             /// `/m/pool/list` - POST
             struct POST {
                 struct Req : Decodable {
-                    let authkey: String
                     let gid: GID
                 }
                 struct Res : Encodable {

--- a/velocity/api/namespaces/vAPI_u/vAPI_u_auth.swift
+++ b/velocity/api/namespaces/vAPI_u/vAPI_u_auth.swift
@@ -61,7 +61,7 @@ extension VAPI {
                 return try self.error(code: .U_AUTH_POST_AUTH_FAILED)
             }
 
-            let key = self.generate_authkey(user: user)
+            let key = self.authenticator.generate_authkey(user: user)
 
             self.VDebug("Authenticated \(user.info()) until \(key.expiration_date().description(with: .current))")
             return try self.response(Structs.U.AUTH.POST.Res(authkey: key.key.uuidString, expires: key.expiration_datetime()))
@@ -72,7 +72,7 @@ extension VAPI {
             let request: Structs.U.AUTH.DELETE.Req = try req.content.decode(Structs.U.AUTH.DELETE.Req.self)
 
             // Search for the key
-            guard let key = self.authkeys.removeValue(forKey: request.authkey) else {
+            guard let key = self.authenticator.authkeys.removeValue(forKey: request.authkey) else {
                 self.VDebug("Key \(request.authkey) hasn't been found")
                 return try self.response(nil)
             }
@@ -87,7 +87,7 @@ extension VAPI {
             let request: Structs.U.AUTH.PATCH.Req = try req.content.decode(Structs.U.AUTH.PATCH.Req.self)
 
             // Search for the key
-            guard let old_key = self.authkeys.removeValue(forKey: request.authkey) else {
+            guard let old_key = self.authenticator.authkeys.removeValue(forKey: request.authkey) else {
                 self.VDebug("Key \(request.authkey) hasn't been found")
                 return try self.error(code: .U_AUTH_PATCH_KEY_NOT_FOUND)
             }
@@ -98,9 +98,9 @@ extension VAPI {
                 return try self.error(code: .U_AUTH_PATCH_KEY_EXPIRED)
             }
 
-            let key = self.generate_authkey(user: old_key.user)
+            let key = self.authenticator.generate_authkey(user: old_key.user)
 
-            self.VDebug("Refreshed key for \(key.user.info()), valid until: \(key.expiration_date().description(with: .current)), \(self.authkeys.count) active keys")
+            self.VDebug("Refreshed key for \(key.user.info()), valid until: \(key.expiration_date().description(with: .current)), \(self.authenticator.authkeys.count) active keys")
             return try self.response(Structs.U.AUTH.PATCH.Res(authkey: key.key.uuidString, expires: key.expiration_datetime()))
         }
     }

--- a/velocity/api/namespaces/vAPI_u/vAPI_u_group.swift
+++ b/velocity/api/namespaces/vAPI_u/vAPI_u_group.swift
@@ -171,14 +171,12 @@ extension VAPI.Structs.U {
         /// `/u/group` - POST
         struct POST {
             struct Req : Decodable {
-                let authkey: String
                 let gid: Int64
             }
         }
         /// `/u/group` - PUT
         struct PUT {
             struct Req : Codable {
-                let authkey: String
                 let parent_gid: Int64
                 let name: String
             }
@@ -191,7 +189,6 @@ extension VAPI.Structs.U {
         /// `/u/group` - DELETE
         struct DELETE {
             struct Req : Codable {
-                let authkey: String
                 let gid: Int64
             }
         }

--- a/velocity/api/namespaces/vAPI_u/vAPI_u_user.swift
+++ b/velocity/api/namespaces/vAPI_u/vAPI_u_user.swift
@@ -231,7 +231,6 @@ extension VAPI.Structs.U {
         /// `/u/user` - PUT
         struct PUT {
             struct Req : Codable {
-                let authkey: String
                 let name: String
                 let password: String
             }
@@ -243,14 +242,12 @@ extension VAPI.Structs.U {
         /// `/u/user` - DELETE
         struct DELETE {
             struct Req : Codable {
-                let authkey: String
                 let uid: Int64
             }
         }
         /// `/u/user` - POST
         struct POST {
             struct Req : Codable {
-                let authkey: String
                 let uid: Int64?
             }
         }
@@ -274,7 +271,6 @@ extension VAPI.Structs.U {
             /// `/u/user/permission` - PUT
             struct PUT {
                 struct Req : Codable {
-                    let authkey: String
                     let uid: Int64
                     let gid: Int64
                     let permission: String
@@ -283,7 +279,6 @@ extension VAPI.Structs.U {
             /// `/u/user/permission` - DELETE
             struct DELETE {
                 struct Req : Decodable {
-                    let authkey: String
                     let uid: Int64
                     let gid: Int64
                     let permission: String?

--- a/velocity/api/namespaces/vAPI_v/vAPI_v_vm.swift
+++ b/velocity/api/namespaces/vAPI_v/vAPI_v_vm.swift
@@ -311,7 +311,6 @@ extension VAPI.Structs.V {
             /// `/v/vm/efi` - PUT
             struct PUT {
                 struct Req : Decodable {
-                    let authkey: String
                     let name: String
                     let gid: GID
 
@@ -336,14 +335,12 @@ extension VAPI.Structs.V {
             /// `/v/vm/state` - POST
             struct POST {
                 struct Req : Decodable {
-                    let authkey: String
                     let vmid: VMID
                 }
             }
             /// `/v/vm/state` - PUT
             struct PUT : Decodable{
                 struct Req : Decodable {
-                    let authkey: String
                     let vmid: VMID
                     let state: VirtualMachine.StateRequest
                     let force: Bool

--- a/velocity/api/namespaces/vAPI_v/vAPI_v_vm.swift
+++ b/velocity/api/namespaces/vAPI_v/vAPI_v_vm.swift
@@ -28,14 +28,13 @@ import Vapor
 extension VAPI {
     /// Registers all endpoints within the namespace `/v/vm`
     func register_endpoints_v_vm(route: RoutesBuilder) throws {
-        route.post("list") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .post("list") { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.V.VM.LIST.POST.Req = try req.content.decode(Structs.V.VM.LIST.POST.Req.self)
-
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard let group = try self.db.group_select(gid: request.gid) else {
                 self.VDebug("\(c_user.info()) tried to list VMs: GROUP \(request.gid) NOT FOUND")
@@ -60,14 +59,13 @@ extension VAPI {
             return try self.response(Structs.V.VM.LIST.POST.Res(vms: vms))
         }
 
-        route.post { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .post { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.V.VM.POST.Req = try req.content.decode(Structs.V.VM.POST.Req.self)
-
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard let vm = self.vm_manager.get_vm(vmid: request.vmid) else {
                 self.VDebug("\(c_user.info()) tried to retrieve VM info: VMID (\(request.vmid)) NOT FOUND")
@@ -99,14 +97,13 @@ extension VAPI {
             return try self.response(res)
         }
 
-        route.put("efi") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .put("efi") { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.V.VM.EFI.PUT.Req = try req.content.decode(Structs.V.VM.EFI.PUT.Req.self)
-
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard try c_user.has_permission(permission: "velocity.vm.create", group: nil) else {
                 self.VDebug("\(c_user.info()) tried to create EFI VM: FORBIDDEN")
@@ -204,14 +201,13 @@ extension VAPI {
 
         }
 
-        route.post("state") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .post("state") { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.V.VM.STATE.POST.Req = try req.content.decode(Structs.V.VM.STATE.POST.Req.self)
-
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard try c_user.has_permission(permission: "velocity.vm.view", group: nil) else {
                 self.VDebug("\(c_user.info()) tried to retrieve VM state: FORBIDDEN")
@@ -226,14 +222,13 @@ extension VAPI {
             return try self.response(Structs.V.VM.STATE.Res(vmid: vm.vvm.vmid, state: vm.get_state().rawValue))
         }
 
-        route.put("state") { req in
+        route
+            .grouped(self.authenticator)
+            .grouped(VDB.User.guardMiddleware())
+            .put("state") { req in
+
+            let c_user = try req.auth.require(VDB.User.self)
             let request: Structs.V.VM.STATE.PUT.Req = try req.content.decode(Structs.V.VM.STATE.PUT.Req.self)
-
-            guard let key = self.get_authkey(authkey: request.authkey) else {
-                return try self.error(code: .UNAUTHORIZED)
-            }
-
-            let c_user = key.user
 
             guard try c_user.has_permission(permission: "velocity.vm.state", group: nil) else {
                 self.VDebug("\(c_user.info()) tried to change VM state: FORBIDDEN")

--- a/velocity/db/tables/vDBTUsers.swift
+++ b/velocity/db/tables/vDBTUsers.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SQLite
+import Vapor
 
 /// The user id is a Int64
 typealias UID = Int64
@@ -15,7 +16,7 @@ extension VDB {
 
     /// A user in the database
     /// > Warning: Altered member variables do not commit to the database unless `commit()` is called on the object
-    class User : Loggable, Encodable {
+    class User : Loggable, Encodable, Authenticatable {
         /// The logging context
         internal let context: String;
         /// A reference to the database for later use


### PR DESCRIPTION
This PR implements the `Bearer` authentication method instead of relying on the old method of sprinkling `authkey` values into the request structures.

This cleans up the codebase and hands the authentication job to one core class to handle it once and (hopefully) bug-free.

Additionally, this minimizes the chance of developer-error as the usage of the new authentication method requires less code per endpoint.